### PR TITLE
Rename modem field in SistemEle model

### DIFF
--- a/src/main/java/com/garsite/SmartBuilder/Model/SistemEle.java
+++ b/src/main/java/com/garsite/SmartBuilder/Model/SistemEle.java
@@ -26,7 +26,7 @@ public class SistemEle {
     private String tipoSensorTemp;          
     private String tipoMedidor;
     private String impresora;
-    private String moden;
+    private String modem;
 
     
 }


### PR DESCRIPTION
## Summary
- fix typo in `SistemEle` by renaming `moden` to `modem`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_689c15b147848325bdb1000058fc7eed